### PR TITLE
new function to speed up DTI

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -26,7 +26,8 @@ save_period: 1
 tensorboard: true
 threshold: 0.5
 threshold_low: 0.3
-DTI: false
+DTI: true
+fast_DTI: false
 amp: true
 tta: false
 CCC: false

--- a/tester.py
+++ b/tester.py
@@ -8,7 +8,7 @@ import torchvision.transforms.functional as TF
 from loguru import logger
 from tqdm import tqdm
 from trainer import Trainer
-from utils.helpers import dir_exists, remove_files, double_threshold_iteration
+from utils.helpers import dir_exists, remove_files, double_threshold_iteration, double_threshold_iteration_fast
 from utils.metrics import AverageMeter, get_metrics, get_metrics, count_connect_component
 import ttach as tta
 
@@ -73,8 +73,12 @@ class Tester(Trainer):
                         f"save_picture/pre_b{i}.png", np.uint8(predict_b*255))
 
                 if self.CFG.DTI:
-                    pre_DTI = double_threshold_iteration(
-                        i, pre, self.CFG.threshold, self.CFG.threshold_low, True)
+                    if self.CFG.fast_DTI:
+                        pre_DTI = double_threshold_iteration_fast(
+                            i, pre, self.CFG.threshold, self.CFG.threshold_low, True)
+                    else:
+                        pre_DTI = double_threshold_iteration(
+                            i, pre, self.CFG.threshold, self.CFG.threshold_low, True)
                     self._metrics_update(
                         *get_metrics(pre, gt, predict_b=pre_DTI).values())
                     if self.CFG.CCC:

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -100,6 +100,25 @@ def double_threshold_iteration(index,img, h_thresh, l_thresh, save=True):
         cv2.imwrite(f"save_picture/gbin{index}.png", gbin)
     return gbin/255
 
+def double_threshold_iteration_fast(index, img, h_thresh, l_thresh, save):
+    img = torch.sigmoid(img).unsqueeze(0) # dim: [1, H, W]
+    
+    normal_mask = (img >= l_thresh).float()
+    fixed_mask = normal_mask.clone()
+    checkable_mask = (img >= l_thresh).float()
+    pre_fixed_mask = torch.zeros_like(fixed_mask) # for comparison
+    
+    while not torch.equal(pre_fixed_mask, fixed_mask):
+        pre_fixed_mask = fixed_mask.clone()
+        fixed_mask = torch.nn.functional.max_pool2d(fixed_mask, 3, 1, 1) * checkable_mask
+    
+    normal_mask = normal_mask.squeeze().cpu().numpy().astype(np.uint8) * 255
+    fixed_mask = fixed_mask.squeeze().cpu().numpy().astype(np.uint8) * 255
+    if save:
+        cv2.imwrite(f"save_picture/bin{index}.png", normal_mask)
+        cv2.imwrite(f"save_picture/gbin{index}.png", fixed_mask)
+    return fixed_mask / 255
+
 
 def recompone_overlap(preds, img_h, img_w, stride_h, stride_w):
     assert (len(preds.shape) == 4)


### PR DESCRIPTION
# PR abstract
I propose Accelerated dual threshold iteration function using **3*3 max-pooling** `double_threshold_iteration_fast`. 

##  new function
In the conventional method, the neighborhood of pixels exceeding the lower threshold was examined for adjacency to the mask. In the proposed approach, efficiency is achieved by checking **whether the pixels adjacent to the mask exceed the lower threshold**.

```python
def double_threshold_iteration_fast(index, img, h_thresh, l_thresh, save):
    img = torch.sigmoid(img).unsqueeze(0) # dim: [1, H, W]
    
    normal_mask = (img >= l_thresh).float()
    fixed_mask = normal_mask.clone()
    checkable_mask = (img >= l_thresh).float()
    pre_fixed_mask = torch.zeros_like(fixed_mask) # for comparison
    
    while not torch.equal(pre_fixed_mask, fixed_mask):
        pre_fixed_mask = fixed_mask.clone()
        fixed_mask = torch.nn.functional.max_pool2d(fixed_mask, 3, 1, 1) * checkable_mask
    
    normal_mask = normal_mask.squeeze().cpu().numpy().astype(np.uint8) * 255
    fixed_mask = fixed_mask.squeeze().cpu().numpy().astype(np.uint8) * 255
    if save:
        cv2.imwrite(f"save_picture/bin{index}.png", normal_mask)
        cv2.imwrite(f"save_picture/gbin{index}.png", fixed_mask)
    return fixed_mask / 255
```

We can select which function we use by option `fast_DTI` in config.yaml;

if `fast_DTI: false`, we use `double_threshold_iteration`.
else (`fast_DTI: true`), `double_threshold_iteration_fast`.

## result (process time)
`double_threshold_iteration`                   : 1.1 [sec/image]
`double_threshold_iteration_fast` (mine) : **0.002 [sec/image]**
(I measured the time before and after the process using `time` package.)

---

I hope my contribution will be marged.
thanks.